### PR TITLE
Refactor: 홈뷰 MBTI 유저디폴트에서 못 가져올 때 처리

### DIFF
--- a/SideProject-MovieApp/Sources/Data/Networks/Service/DataTransferService.swift
+++ b/SideProject-MovieApp/Sources/Data/Networks/Service/DataTransferService.swift
@@ -26,7 +26,7 @@ final class DataTransferService {
             let decodedData = try JSONDecoder().decode(T.self, from: responseData)
             return decodedData
         } catch {
-            print("👊", DataTransferError.decode)
+            print("❌ Error From: \(target.request)")
             throw DataTransferError.decode
         }
     }

--- a/SideProject-MovieApp/Sources/Presents/TabBar/HomeView/MainView/HomeViewController.swift
+++ b/SideProject-MovieApp/Sources/Presents/TabBar/HomeView/MainView/HomeViewController.swift
@@ -49,8 +49,6 @@ final class HomeViewController: BaseViewController {
     let categoryTitle = PublishRelay<String>()
     let viewDidLoadTrigger = PublishRelay<Void>()
     
-    let mbti = UserDefaultManager.mbti ?? "ISFJ"
-    
     override func loadView() {
         view = homeView
     }
@@ -74,7 +72,18 @@ final class HomeViewController: BaseViewController {
     }
     
     override func setupBinding() {
-        let input = HomeViewModel.Input(categoryButtonTapped: self.homeView.categoryButton.rx.tap.withLatestFrom(self.categoryTitle).asSignal(onErrorJustReturn: "영화"), heroPlusButtonTapped: self.homeView.mbtiHeroMoreButton.rx.tap, characterPlusButtonTapped: self.homeView.characterMoreButton.rx.tap, mbtiRecommendPlusButtonTapped: self.homeView.recommendMoreButton.rx.tap, hotMoviePlusButtonTapped: self.homeView.nowHotMoreButton.rx.tap, posterCellSelected: posterCellSelected, mbtiHeroCellSelected: self.mbtiHeroCellSelected, mbtiRecommendCellSeleted: self.mbtiRecommendCellSeleted, hotMovieCellSelected: self.hotMovieCellSelected, viewDidLoad: self.viewDidLoadTrigger, okAlertButtonTapped: self.homeView.alertView.okButton.rx.tap, cancelAlertButtonTapped: self.homeView.alertView.cancelButton.rx.tap)
+        let input = HomeViewModel.Input(categoryButtonTapped: self.homeView.categoryButton.rx.tap.withLatestFrom(self.categoryTitle).asSignal(onErrorJustReturn: "영화"),
+                                        heroPlusButtonTapped: self.homeView.mbtiHeroMoreButton.rx.tap,
+                                        characterPlusButtonTapped: self.homeView.characterMoreButton.rx.tap,
+                                        mbtiRecommendPlusButtonTapped: self.homeView.recommendMoreButton.rx.tap,
+                                        hotMoviePlusButtonTapped: self.homeView.nowHotMoreButton.rx.tap,
+                                        posterCellSelected: posterCellSelected,
+                                        mbtiHeroCellSelected: self.mbtiHeroCellSelected,
+                                        mbtiRecommendCellSeleted: self.mbtiRecommendCellSeleted,
+                                        hotMovieCellSelected: self.hotMovieCellSelected,
+                                        viewDidLoad: self.viewDidLoadTrigger,
+                                        okAlertButtonTapped: self.homeView.alertView.okButton.rx.tap,
+                                        cancelAlertButtonTapped: self.homeView.alertView.cancelButton.rx.tap)
         
         let output = self.viewModel.transform(input: input)
         
@@ -161,6 +170,7 @@ final class HomeViewController: BaseViewController {
             }
             .disposed(by: disposeBag)
     }
+    
 }
 
 //MARK: PosterDataSource 설정
@@ -177,8 +187,7 @@ extension HomeViewController {
         
         let todayDIMOHeader = UICollectionView.SupplementaryRegistration<TodayDIMOHeaderView>(elementKind: TodayDIMOHeaderView.identifier) { supplementaryView, elementKind, indexPath in
             self.categoryTitle
-                .bind { [weak self] title in
-                    guard let self else { return }
+                .bind { title in
                     supplementaryView.categoryInsetLabel.text = title
                 }
                 .disposed(by: self.disposeBag)
@@ -205,7 +214,11 @@ extension HomeViewController {
         
         let myMomentumHeader = UICollectionView.SupplementaryRegistration<MyMomentumHeaderView>(elementKind: MyMomentumHeaderView.identifier) { [weak self] supplementaryView, elementKind, indexPath in
             guard let self = self else { return }
-            supplementaryView.titleLabel.text = "\(self.mbti)가 주인공인 영화"
+            self.viewModel.mbti
+                .bind { mbti in
+                    supplementaryView.titleLabel.text = "\(mbti)가 주인공인 영화"
+                }
+                .disposed(by: disposeBag)
         }
         
         mbtiHeroDataSource.supplementaryViewProvider = .some({ collectionView, elementKind, indexPath in
@@ -228,9 +241,13 @@ extension HomeViewController {
             return cell
         }
         
-        let myMomentumHeader = UICollectionView.SupplementaryRegistration<MyMomentumHeaderView>(elementKind: MyMomentumHeaderView.identifier) {  [weak self] supplementaryView, elementKind, indexPath in
+        let myMomentumHeader = UICollectionView.SupplementaryRegistration<MyMomentumHeaderView>(elementKind: MyMomentumHeaderView.identifier) { [weak self] supplementaryView, elementKind, indexPath in
             guard let self = self else { return }
-            supplementaryView.titleLabel.text = "스포주의! \(self.mbti) 캐릭터 모아보기"
+            self.viewModel.mbti
+                .bind { mbti in
+                    supplementaryView.titleLabel.text = "스포주의! \(mbti) 캐릭터 모아보기"
+                }
+                .disposed(by: disposeBag)
         }
         
         characterDataSource.supplementaryViewProvider = .some({ collectionView, elementKind, indexPath in
@@ -255,7 +272,11 @@ extension HomeViewController {
         
         let myMomentumHeader = UICollectionView.SupplementaryRegistration<MyMomentumHeaderView>(elementKind: MyMomentumHeaderView.identifier) { [weak self] supplementaryView, elementKind, indexPath in
             guard let self = self else { return }
-            supplementaryView.titleLabel.text = "\(self.mbti)가 관심있는 영화/애니"
+            self.viewModel.mbti
+                .bind { mbti in
+                    supplementaryView.titleLabel.text = "\(mbti)가 관심있는 영화/애니"
+                }
+                .disposed(by: disposeBag)
         }
         
         recommendDataSource.supplementaryViewProvider = .some({ collectionView, elementKind, indexPath in


### PR DESCRIPTION
- 기존 홈뷰에서 mbti를 유저디폴트에서 가져왔는데 값이 없을 경우를 위해 getProfile API호출 후 MBTI를 저장해 홈뷰에서 처리하는 식으로 변경하였습니다.